### PR TITLE
fix: tolerate Capacitor sync addListener handles on Android

### DIFF
--- a/ui/desktop/src/renderer/platform/bridge.test.ts
+++ b/ui/desktop/src/renderer/platform/bridge.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  attachAndroidListener,
+  getPlatformBridge,
+  type AndroidPlugin,
+  type PluginListenerHandle,
+} from "./bridge";
+
+/** Mirrors Capacitor Android JSExport: addListener returns a sync { remove } handle. */
+function createSyncCapacitorPlugin(): {
+  plugin: AndroidPlugin;
+  remove: ReturnType<typeof vi.fn>;
+  listeners: Map<string, (payload: Record<string, unknown>) => void>;
+} {
+  const listeners = new Map<string, (payload: Record<string, unknown>) => void>();
+  const remove = vi.fn().mockResolvedValue(undefined);
+  const plugin = {
+    bootstrap: vi.fn(),
+    apiRequest: vi.fn(),
+    chooseDownloadTree: vi.fn(),
+    pickTorrentFile: vi.fn(),
+    openDownloadedFile: vi.fn(),
+    shareDownloadedFile: vi.fn(),
+    setTransferPolicy: vi.fn(),
+    pauseAll: vi.fn(),
+    addListener(event: string, callback: (payload: Record<string, unknown>) => void): PluginListenerHandle {
+      listeners.set(event, callback);
+      return { remove };
+    },
+  } as unknown as AndroidPlugin;
+  return { plugin, remove, listeners };
+}
+
+describe("attachAndroidListener", () => {
+  it("tolerates Capacitor's sync addListener handle (the #22 crash)", () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const addListener = vi.fn().mockReturnValue({ remove });
+    const plugin = { addListener } as Pick<AndroidPlugin, "addListener">;
+    const callback = vi.fn();
+
+    // Old code did: plugin.addListener(...).then(...) which throws TypeError.
+    expect(() => {
+      const raw = plugin.addListener("appStateChange", callback);
+      expect(typeof (raw as { then?: unknown }).then).not.toBe("function");
+    }).not.toThrow();
+
+    const unsubscribe = attachAndroidListener(plugin, "appStateChange", callback);
+    expect(addListener).toHaveBeenCalledWith("appStateChange", callback);
+    unsubscribe();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+
+  it("also accepts Promise-returning addListener (registerPlugin style)", async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const addListener = vi.fn().mockResolvedValue({ remove });
+    const plugin = { addListener } as Pick<AndroidPlugin, "addListener">;
+
+    const unsubscribe = attachAndroidListener(plugin, "magnetLink", vi.fn());
+    await Promise.resolve();
+    unsubscribe();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});
+
+describe("android bridge onAppStateChange (issue #22 regression)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers appStateChange without TypeError when Capacitor returns a sync handle", () => {
+    const { plugin, remove, listeners } = createSyncCapacitorPlugin();
+    vi.stubGlobal("window", {
+      Capacitor: {
+        getPlatform: () => "android",
+        Plugins: { OrcAndroid: plugin },
+      },
+    });
+
+    const bridge = getPlatformBridge();
+    expect(bridge.platform).toBe("android");
+
+    const onActive = vi.fn();
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = bridge.onAppStateChange(onActive);
+    }).not.toThrow();
+
+    listeners.get("appStateChange")?.({ active: true });
+    expect(onActive).toHaveBeenCalledWith(true);
+
+    listeners.get("appStateChange")?.({ active: false });
+    expect(onActive).toHaveBeenCalledWith(false);
+
+    unsubscribe?.();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+
+  it("registers magnet and torrent listeners with sync Capacitor handles", () => {
+    const { plugin, remove, listeners } = createSyncCapacitorPlugin();
+    vi.stubGlobal("window", {
+      Capacitor: {
+        getPlatform: () => "android",
+        Plugins: { OrcAndroid: plugin },
+      },
+    });
+
+    const bridge = getPlatformBridge();
+    const onMagnet = vi.fn();
+    const onTorrent = vi.fn();
+
+    expect(() => {
+      bridge.onMagnetLink(onMagnet);
+      bridge.onTorrentFile(onTorrent);
+    }).not.toThrow();
+
+    listeners.get("magnetLink")?.({ uri: "magnet:?xt=urn:btih:abc" });
+    expect(onMagnet).toHaveBeenCalledWith("magnet:?xt=urn:btih:abc");
+
+    listeners.get("torrentFile")?.({ name: "x.torrent", base64: "YmFzZTY0" });
+    expect(onTorrent).toHaveBeenCalledWith({ name: "x.torrent", base64: "YmFzZTY0" });
+    expect(remove).not.toHaveBeenCalled();
+  });
+});

--- a/ui/desktop/src/renderer/platform/bridge.ts
+++ b/ui/desktop/src/renderer/platform/bridge.ts
@@ -31,6 +31,10 @@ export interface PlatformBridge {
   onTorrentFile(callback: (file: PickedTorrentFile) => void): () => void;
 }
 
+export type PluginListenerHandle = {
+  remove(): Promise<void>;
+};
+
 export type AndroidPlugin = {
   bootstrap(): Promise<AndroidBootstrap>;
   apiRequest(options: {
@@ -47,7 +51,7 @@ export type AndroidPlugin = {
   addListener(
     event: "magnetLink" | "torrentFile" | "appStateChange",
     callback: (payload: { uri?: string; name?: string; base64?: string; active?: boolean }) => void
-  ): Promise<{ remove(): Promise<void> }>;
+  ): PluginListenerHandle | Promise<PluginListenerHandle>;
 };
 
 function androidPlugin(): AndroidPlugin | null {
@@ -55,6 +59,30 @@ function androidPlugin(): AndroidPlugin | null {
 }
 
 const noop = () => {};
+
+function isThenable<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as PromiseLike<T>)?.then === "function";
+}
+
+/** Capacitor's injected Plugins.*.addListener returns a sync handle; registerPlugin returns a Promise. */
+export function attachAndroidListener(
+  plugin: Pick<AndroidPlugin, "addListener">,
+  event: "magnetLink" | "torrentFile" | "appStateChange",
+  callback: (payload: { uri?: string; name?: string; base64?: string; active?: boolean }) => void
+): () => void {
+  let handle: PluginListenerHandle | null = null;
+  const result = plugin.addListener(event, callback);
+  // Injected Capacitor stubs return { remove } sync. registerPlugin may return a Promise
+  // that also exposes .remove, or a plain Promise of the handle.
+  if (typeof (result as PluginListenerHandle)?.remove === "function") {
+    handle = result as PluginListenerHandle;
+  } else if (isThenable(result)) {
+    void Promise.resolve(result).then((value) => {
+      handle = value;
+    });
+  }
+  return () => void handle?.remove();
+}
 
 const androidBridge: PlatformBridge = {
   platform: "android",
@@ -94,29 +122,21 @@ const androidBridge: PlatformBridge = {
   onAppStateChange(callback) {
     const plugin = androidPlugin();
     if (!plugin) return noop;
-    let handle: { remove(): Promise<void> } | null = null;
-    void plugin
-      .addListener("appStateChange", ({ active }) => callback(active === true))
-      .then((value) => (handle = value));
-    return () => void handle?.remove();
+    return attachAndroidListener(plugin, "appStateChange", ({ active }) => callback(active === true));
   },
   onMagnetLink(callback) {
     const plugin = androidPlugin();
     if (!plugin) return noop;
-    let handle: { remove(): Promise<void> } | null = null;
-    void plugin.addListener("magnetLink", ({ uri }) => uri && callback(uri)).then((value) => (handle = value));
-    return () => void handle?.remove();
+    return attachAndroidListener(plugin, "magnetLink", ({ uri }) => {
+      if (uri) callback(uri);
+    });
   },
   onTorrentFile(callback) {
     const plugin = androidPlugin();
     if (!plugin) return noop;
-    let handle: { remove(): Promise<void> } | null = null;
-    void plugin
-      .addListener("torrentFile", ({ name, base64 }) => {
-        if (name && base64) callback({ name, base64 });
-      })
-      .then((value) => (handle = value));
-    return () => void handle?.remove();
+    return attachAndroidListener(plugin, "torrentFile", ({ name, base64 }) => {
+      if (name && base64) callback({ name, base64 });
+    });
   },
 };
 


### PR DESCRIPTION
Capacitor's injected OrcAndroid.addListener returns a sync { remove } handle, so calling .then() crashed startup with issue #22. Normalize listener registration for both sync and Promise-based plugin APIs.